### PR TITLE
Add pip-audit security badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 [![Security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
+[![Security: pip-audit](https://img.shields.io/badge/security-pip--audit-purple.svg)](https://github.com/pypa/pip-audit)
 
 REST Incantation is a Flask-based tool for exploring REST APIs from their OpenAPI documentation. It supports fetching OpenAPI docs from a base URL, detecting auth schemes, and guiding users through credential entry.
 


### PR DESCRIPTION
## Summary
- Add pip-audit security badge to README alongside existing bandit badge

## Test plan
- [ ] Verify badge renders correctly in README