### PR TITLE
Fix Docker container host binding for external access

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,11 @@ RUN pip install --no-cache-dir -r requirements.txt pytest-cov
 # Copy application code
 COPY . .
 
+# Set Flask app
+ENV FLASK_APP=app.py
+
 # Expose Flask port
 EXPOSE 5000
 
-# Default command runs the app
-CMD ["python", "app.py"]
+# Default command runs the app (bind to 0.0.0.0 for container access)
+CMD ["flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
## Summary
- Bind Flask to `0.0.0.0` instead of `127.0.0.1` so the app is accessible from outside the container
- Add `FLASK_APP` environment variable for `flask run` command

## Test plan
- [x] `docker compose build` succeeds
- [x] `docker compose up` starts the app
- [x] `curl http://localhost:5000/` returns HTTP 200
- [x] All 39 tests pass in Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)