### PR TITLE
Add Docker build and test job to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,3 +82,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+      - name: Build Docker image
+        run: docker compose -f docker/docker-compose.yml build
+      - name: Run tests in Docker
+        run: docker compose -f docker/docker-compose.yml run --rm test


### PR DESCRIPTION
## Summary
- Add new `docker` job to CI workflow
- Builds Docker image using `docker compose`
- Runs test suite inside Docker container

## Test plan
- [ ] CI workflow runs successfully
- [ ] Docker build step completes
- [ ] Docker test step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)