### PR TITLE
ci: migrate safe jobs to self-hosted runner

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       issues: write
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
       - name: Set up Python
@@ -25,7 +25,7 @@ jobs:
         run: ruff format --check .
 
   typecheck:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
       - name: Set up Python
@@ -41,7 +41,7 @@ jobs:
         run: mypy .
 
   security:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
       - name: Set up Python
@@ -57,7 +57,7 @@ jobs:
         run: pip-audit
 
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v6
       - name: Set up Python


### PR DESCRIPTION
## Summary
- 6 safe jobs flipped from `ubuntu-latest` → `self-hosted` (Cerebrum runner).
- `docker` job stays on cloud pending Colima socket access verification.

## Migrated
- `tests.yml` `lint` (ruff)
- `tests.yml` `typecheck` (mypy)
- `tests.yml` `security` (bandit + pip-audit)
- `tests.yml` `pytest` + codecov upload
- `dependabot-auto-merge.yml` `auto-merge`
- `labels.yml` `sync`

## Kept on cloud
- `tests.yml` `docker` — runs docker-compose; needs Docker daemon socket access on the runner. Flip later after verifying Colima context is exported in the runner's environment.

## Test plan
- [ ] Tests run green on this PR (especially pytest)
- [ ] codecov upload still works from self-hosted (uses CODECOV_TOKEN if private; not needed for public)