### PR TITLE
ci: correct codecov-action pin comment to v7.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           name: coverage-report
           path: coverage.xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml


### PR DESCRIPTION
The inline version annotation on the codecov-action pin read `# v5` across multiple SHA bumps, while PR #73 advanced the pinned SHA to v7.0.0.

This corrects the comment so it accurately documents the pinned release. **The SHA is unchanged** — no runtime/behavior change; Actions only reads the SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)