### PR TITLE
deps: remove unused authlib dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ requests==2.34.2
 APScheduler==3.11.2
 PyYAML==6.0.3
 pytest==9.1.0
-authlib==1.7.2
 cryptography==49.0.0


### PR DESCRIPTION
`authlib` was added in `0865d81` alongside the auth system but is **never imported** in any commit (`git log --all -S 'import authlib'` / `'from authlib'` are both empty).

The repo's OAuth2 flows are hand-rolled in `auth/oauth2_flows.py` on `requests` + stdlib (`base64`/`hashlib`/`secrets`/`urllib`); the `OAuth2*` classes are the project's own, not authlib's. No other dependency pulls it in transitively.

Dropping the dead dependency removes an unused patch surface (authlib has a history of JWT/JOSE CVEs) and shrinks the install/image. CI should stay green since nothing imports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)