### PR TITLE
deps: split test dependencies into requirements-dev.txt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt pytest-cov
+          pip install -r requirements-dev.txt
       - name: Run tests with coverage
         run: pytest --cov=. --cov-report=term --cov-report=xml
       - name: Upload coverage report

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ cd rest-Incantation
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
-# Install dependencies
-pip install -r requirements.txt
+# Install dependencies (runtime + test toolchain)
+pip install -r requirements-dev.txt
 
 # Install pre-commit hooks (recommended)
 pip install pre-commit

--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ Hooks run automatically on commit:
 - **mypy** - type checking
 
 ## Testing
+Install the development dependencies (runtime deps plus the test toolchain), then run the suite:
 ```bash
+pip install -r requirements-dev.txt
+
 pytest
 
 # With coverage

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install dependencies
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt pytest-cov
+# Install dependencies (runtime + test toolchain; the test service runs pytest)
+COPY requirements.txt requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements-dev.txt
 
 # Copy application code
 COPY . .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Development/test dependencies.
+# Installs the runtime requirements plus the test toolchain.
+-r requirements.txt
+pytest==9.1.0
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ Flask==3.1.3
 requests==2.34.2
 APScheduler==3.11.2
 PyYAML==6.0.3
-pytest==9.1.0
 cryptography==49.0.0


### PR DESCRIPTION
Separates test tooling from runtime dependencies.

- `requirements.txt` is now **runtime-only**.
- New `requirements-dev.txt` pulls in the runtime set (`-r requirements.txt`) plus `pytest==9.1.0` and `pytest-cov` (the latter was previously installed ad-hoc in CI and the Dockerfile — now centralized).

Updated the contexts that actually run pytest to install the dev file:
- CI **pytest** job → `pip install -r requirements-dev.txt`
- **Dockerfile** (its `test` compose service runs pytest) → copies + installs `requirements-dev.txt`

Unchanged on purpose: the **typecheck** job (mypy uses `ignore_missing_imports = true`) and **security** job (audits the runtime surface). README/CONTRIBUTING now point contributors at the dev file.

The `docker` CI job exercises the Dockerfile change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)