### PR TITLE
ci: audit dev deps in security job and pin pytest-cov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.11"
           cache: "pip"
       - name: Install dependencies
-        run: pip install -r requirements.txt bandit[toml] pip-audit
+        run: pip install -r requirements-dev.txt bandit[toml] pip-audit
       - name: Run bandit
         run: bandit -c pyproject.toml -r .
       - name: Run pip-audit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ docker compose up --build
 |------|---------|---------|
 | **ruff** | Linting and formatting | `pip install ruff` |
 | **mypy** | Type checking | `pip install mypy` |
-| **pytest** | Testing | `pip install pytest pytest-cov` |
+| **pytest** | Testing | included in `requirements-dev.txt` |
 | **bandit** | Security scanning | `pip install bandit` |
 | **pre-commit** | Git hooks | `pip install pre-commit` |
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@
 # Installs the runtime requirements plus the test toolchain.
 -r requirements.txt
 pytest==9.1.0
-pytest-cov
+pytest-cov==7.1.0


### PR DESCRIPTION
Follow-ups from the review of #77:

1. **Security audit coverage** — the `security` job now installs `requirements-dev.txt`, so `pip-audit` scans the test toolchain (pytest/pytest-cov) again. After #77 moved pytest out of `requirements.txt`, those packages were no longer installed in that job and thus no longer audited.
2. **Pin `pytest-cov==7.1.0`** — it was the only unpinned dependency; now CI and the Docker image build reproducibly, consistent with every other pin. (7.1.0 is the current latest, i.e. what CI was already resolving.)
3. **Docs** — the CONTRIBUTING tooling table now points at `requirements-dev.txt` instead of an unpinned `pip install pytest pytest-cov`.

Note: with pytest/pytest-cov back in the audited set, the `security` job (`pip-audit`) is the real gate here — if it goes green, no known CVEs in the pinned test deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)