### PR TITLE
docs: align README CI Checks with the actual workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,10 +199,11 @@ The config directory is mounted read-only into the container.
 
 ## CI Checks
 All checks run automatically on push and pull requests:
-- **pytest** - tests with coverage reporting
 - **ruff** - linting and formatting
 - **mypy** - type checking
-- **bandit** - security scanning
+- **bandit** + **pip-audit** - security scanning and dependency vulnerability audit
+- **pytest** - tests with coverage reporting (uploaded to Codecov)
+- **Docker** - builds the image and runs the test suite in a container
 
 ## Troubleshooting
 - OpenAPI fetch fails: confirm the base URL is reachable and that `/openapi.json` or `/openapi.yaml` exists.


### PR DESCRIPTION
The README **CI Checks** section listed only pytest/ruff/mypy/bandit, omitting the `pip-audit` step (run in the security job) and the `docker` job entirely.

Updated to reflect all five workflow jobs — lint, typecheck, security (bandit + pip-audit), pytest (→ Codecov), and docker — matching the list already in CONTRIBUTING.md.

Also confirmed clean during the sweep: no `authlib` references remain in any doc, and `docs/ARCHITECTURE.md` (Flask/APScheduler/Fernet) is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)