### PR TITLE
docker: multi-stage build to slim the runtime image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,27 @@
-FROM python:3.11-slim
+# Shared base: runtime dependencies + application code.
+FROM python:3.11-slim AS base
 
 WORKDIR /app
 
-# Install dependencies (runtime + test toolchain; the test service runs pytest)
-COPY requirements.txt requirements-dev.txt ./
-RUN pip install --no-cache-dir -r requirements-dev.txt
+# Runtime dependencies only (no test toolchain).
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy application code
+# Copy application code.
 COPY . .
 
-# Set Flask app
+# Set Flask app and expose its port.
 ENV FLASK_APP=app.py
-
-# Expose Flask port
 EXPOSE 5000
 
-# Default command runs the app (bind to 0.0.0.0 for container access)
+# Production image — runtime dependencies only. Selected by the `app`
+# compose service via `target: runtime`.
+FROM base AS runtime
+# Bind to 0.0.0.0 for container access.
 CMD ["flask", "run", "--host=0.0.0.0"]
+
+# Test image — adds the dev/test toolchain on top of the runtime base.
+# Selected by the `test` compose service via `target: test`.
+FROM base AS test
+RUN pip install --no-cache-dir -r requirements-dev.txt
+CMD ["pytest", "-v", "--cov=.", "--cov-report=term"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+      target: runtime
     ports:
       - "5000:5000"
     environment:
@@ -19,6 +20,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+      target: test
     command: pytest -v --cov=. --cov-report=term
     environment:
       - FLASK_SECRET_KEY=test-key


### PR DESCRIPTION
Addresses review finding #2 from #77 — the single Dockerfile installed `requirements-dev.txt`, so the production `app` image shipped pytest/pytest-cov.

**Change:** split into three stages:
- `base` — runtime deps (`requirements.txt`) + application code
- `runtime` — the production `app` image; **runtime deps only, no test toolchain**
- `test` — layers `requirements-dev.txt` on top of `base` for the `test` service

docker-compose selects the stage per service via `build.target` (`app` → `runtime`, `test` → `test`). The `.dockerignore` already keeps `.git`/`docs/`/venvs/caches out of the context, so this removes the last source of bloat (the test packages) from the runtime image.

**Validation:** the CI `docker` job builds the `app` service (→ `runtime` target) and runs `docker compose run --rm test` (→ `test` target) — exercising both stages and running the suite in the test image. The app needs only runtime deps (no app module imports pytest), which the `pytest` job already proves, so the slim runtime image is functionally complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)