### PR TITLE
docs: fix stale static-analysis config reference in BEST_PRACTICES

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -13,7 +13,7 @@
 - Follow PEP 8 and keep modules single‑purpose.
 - Avoid import‑time side effects; expose functions and wire them in `app.py`.
 - Keep Flask routes small; move complex logic into helper modules.
-- Keep static analysis config in `qodana.yaml` and prefer CI checks over local overrides.
+- Keep static analysis config in `pyproject.toml` (`ruff`, `mypy`, `bandit`) and prefer CI checks over local overrides.
 
 ## Testing
 - Add tests for parsing, auth detection, and route behavior.


### PR DESCRIPTION
BEST_PRACTICES.md pointed static-analysis config at a non-existent `qodana.yaml`. Verified there is no Qodana config anywhere in the repo and CI does not run Qodana — the actual config lives in `pyproject.toml` (`[tool.ruff]`, `[tool.mypy]`, `[tool.bandit]`), run by the lint/typecheck/security jobs. Updated the line to match.

Part of a broader doc re-audit. Everything else checked out accurate: README/CONTRIBUTING install + Docker commands, the env vars in BEST_PRACTICES (`FLASK_SECRET_KEY`, `REST_INCANTATION_SECRETS` both real), `docs/ARCHITECTURE.md` file tree (incl. correctly-documented gitignored `secrets.yaml` / runtime `data/credentials`), and SECURITY.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)