### PR TITLE
docs: normalize templates/ trees to the actual layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,14 @@ token = get_token()
 │   ├── storage.py         # Credential storage backends
 │   ├── token_manager.py   # Token renewal scheduler
 │   └── header_builder.py  # HTTP header construction
-├── templates/
-│   ├── base.html          # Base template with Tailwind
-│   ├── components/        # Auth form components
-│   └── partials/          # Reusable UI fragments
+├── templates/                # Jinja2 + Tailwind templates
+│   ├── base.html             # Base layout
+│   ├── index.html            # Landing page
+│   ├── submit_url.html       # OpenAPI URL entry
+│   ├── credentials.html      # Auth credential entry
+│   ├── request_builder.html  # Request builder UI
+│   ├── components/           # Auth form components (apikey, basic, bearer, jwt, oauth2, headers)
+│   └── partials/             # Reusable fragments (flash messages)
 ├── credential_method.py   # OpenAPI auth detection
 └── bearer_tokens.py       # Legacy token helper
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -342,10 +342,20 @@ rest-Incantation/
 │   └── header_builder.py    # HTTP header construction
 │
 ├── templates/               # Jinja2 HTML templates
+│   ├── base.html
 │   ├── index.html
 │   ├── submit_url.html
 │   ├── credentials.html
-│   └── request_builder.html
+│   ├── request_builder.html
+│   ├── components/          # Auth form components
+│   │   ├── auth_form_apikey.html
+│   │   ├── auth_form_basic.html
+│   │   ├── auth_form_bearer.html
+│   │   ├── auth_form_jwt.html
+│   │   ├── auth_form_oauth2.html
+│   │   └── custom_headers.html
+│   └── partials/
+│       └── flash_messages.html
 │
 ├── config/
 │   ├── secrets.yaml         # Runtime secrets (gitignored)


### PR DESCRIPTION
The README and `docs/ARCHITECTURE.md` structure trees each listed a different, incomplete subset of `templates/`. Both now match the real layout:

- **README** — readable overview: `base.html` + the four page templates, with `components/` and `partials/` annotated.
- **ARCHITECTURE** — full enumeration, including the six `components/` templates and `partials/flash_messages.html`. Verified to list exactly the 12 actual template files (no extras, no omissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)